### PR TITLE
Optimize scan_data functions via std::find

### DIFF
--- a/cmake.toml
+++ b/cmake.toml
@@ -5,15 +5,13 @@ cmake-before="""
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
 """
 
-[fetch-content.bddisasm]
-git = "https://github.com/bitdefender/bddisasm"
-tag = "v1.37.0"
-shallow = true
+[vcpkg]
+version = "2022.07.25"
+packages = ["spdlog", "bddisasm"]
 
-[fetch-content.spdlog]
-git = "https://github.com/gabime/spdlog"
-tag = "v1.12.0"
-shallow = true
+[find-package]
+spdlog = { required = false }
+bddisasm = { required = false }
 
 [template.kananlib-template]
 type = "static"

--- a/cmake.toml
+++ b/cmake.toml
@@ -5,13 +5,15 @@ cmake-before="""
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
 """
 
-[vcpkg]
-version = "2022.07.25"
-packages = ["spdlog", "bddisasm"]
+[fetch-content.bddisasm]
+git = "https://github.com/bitdefender/bddisasm"
+tag = "v1.37.0"
+shallow = true
 
-[find-package]
-spdlog = { required = false }
-bddisasm = { required = false }
+[fetch-content.spdlog]
+git = "https://github.com/gabime/spdlog"
+tag = "v1.12.0"
+shallow = true
 
 [template.kananlib-template]
 type = "static"

--- a/src/Scan.cpp
+++ b/src/Scan.cpp
@@ -56,11 +56,14 @@ namespace utility {
 
     optional<uintptr_t> scan_data(HMODULE module, const uint8_t* data, size_t size) {
         const auto module_size = get_module_size(module).value_or(0);
-        const auto end = (uintptr_t)module + module_size;
+        auto it = (uint8_t*)module;
+        const auto end = (uint8_t*)module + module_size;
 
-        for (auto i = (uintptr_t)module; i < end; i += sizeof(uint8_t)) {
-            if (memcmp((void*)i, data, size) == 0) {
-                return i;
+        while (end != (it = std::find(it, end, *data))) {
+            if (memcmp(it, data, size) == 0) {
+                return (uintptr_t)it;
+            } else {
+                it++;
             }
         }
 
@@ -72,9 +75,13 @@ namespace utility {
             return {};
         }
 
-        for (auto i = start; i < start + length; i += sizeof(uint8_t)) {
-            if (memcmp((void*)i, data, size) == 0) {
-                return i;
+        auto it = (uint8_t*)start;
+        const auto end = (uint8_t*)start + length;
+        while (end != (it = std::find(it, end, *data))) {
+            if (memcmp(it, data, size) == 0) {
+                return (uintptr_t)it;
+            } else {
+                it++;
             }
         }
 


### PR DESCRIPTION
Swaps to using std::find to find the first byte in the data and then memcmp the buffer following that point rather than a basic iterator.  std::find is optimized for each compiler (generally using memchr on the backend).  

This resulted in anywhere from a 10x to 30x+ performance increase across a number of tests.

