### PR TITLE
SPDLOG: check availability

### DIFF
--- a/include/utility/Benchmark.hpp
+++ b/include/utility/Benchmark.hpp
@@ -1,7 +1,14 @@
 #pragma once
 
 #include <chrono>
+
+#if __has_include(<spdlog/spdlog.h>)
 #include <spdlog/spdlog.h>
+#else
+#define SPDLOG_INFO(...)
+#define SPDLOG_ERROR(...)
+#define SPDLOG_DEBUG(...)
+#endif
 
 //#define KANANLIB_DO_BENCHMARK
 

--- a/include/utility/thirdparty/parallel-util.hpp
+++ b/include/utility/thirdparty/parallel-util.hpp
@@ -35,7 +35,13 @@ SOFTWARE.
 
 // #define PARALLELUTIL_VERBOSE
 
+#if __has_include(<spdlog/spdlog.h>)
 #include <spdlog/spdlog.h>
+#else
+#define SPDLOG_INFO(...)
+#define SPDLOG_ERROR(...)
+#define SPDLOG_DEBUG(...)
+#endif
 
 #include <functional>
 #include <mutex>
@@ -88,7 +94,7 @@ namespace parallelutil
         std::vector<std::unique_ptr<std::thread>> threads{};
         threads.reserve(n_threads);
         for (int j = 0; j < n_threads; ++ j) { threads.push_back(std::make_unique<std::thread>(inner_loop, j)); }
-        for (auto& t : threads) try { if (t->joinable()) t->join(); } catch(...) { spdlog::error("Exception occurred trying to join a thread"); } // do we not care? lets find out.
+        for (auto& t : threads) try { if (t->joinable()) t->join(); } catch(...) { SPDLOG_ERROR("Exception occurred trying to join a thread"); } // do we not care? lets find out.
     }
 
     template<typename N, typename Callable>

--- a/src/Emulation.cpp
+++ b/src/Emulation.cpp
@@ -2,7 +2,13 @@
 #include <bdshemu.h>
 #include <disasmtypes.h>
 
+#if __has_include(<spdlog/spdlog.h>)
 #include <spdlog/spdlog.h>
+#else
+#define SPDLOG_INFO(...)
+#define SPDLOG_ERROR(...)
+#define SPDLOG_DEBUG(...)
+#endif
 
 #include <utility/Module.hpp>
 #include <utility/Emulation.hpp>
@@ -126,7 +132,7 @@ void emulate(HMODULE module, uintptr_t ip, size_t num_instructions, ShemuContext
         const auto ix = utility::decode_one((uint8_t*)emu.ctx->Registers.RegRip);
 
         if (!ix) {
-            spdlog::error("Failed to decode instruction at {:x}", emu.ctx->Registers.RegRip);
+            SPDLOG_ERROR("Failed to decode instruction at {:x}", emu.ctx->Registers.RegRip);
             break;
         }
 
@@ -150,12 +156,12 @@ void emulate(HMODULE module, uintptr_t ip, size_t num_instructions, ShemuContext
         const auto emu_failed = emu.emulate() != SHEMU_SUCCESS;
 
         if (emu_failed) {
-            spdlog::error("Emulation failed at {:x}", emu.ctx->Registers.RegRip);
+            SPDLOG_ERROR("Emulation failed at {:x}", emu.ctx->Registers.RegRip);
 
             const auto ix_cur = utility::decode_one((uint8_t*)emu.ctx->Registers.RegRip);
 
             if (!ix_cur) {
-                spdlog::error("Failed to decode instruction at {:x}", emu.ctx->Registers.RegRip);
+                SPDLOG_ERROR("Failed to decode instruction at {:x}", emu.ctx->Registers.RegRip);
                 break;
             }
 
@@ -164,7 +170,7 @@ void emulate(HMODULE module, uintptr_t ip, size_t num_instructions, ShemuContext
             ++emu.ctx->InstructionsCount;
         }
     } catch (...) {
-        spdlog::error("Exception in emulation loop");
+        SPDLOG_ERROR("Exception in emulation loop");
         break;
     }
 }

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -3,12 +3,19 @@
 #include <fstream>
 #include <filesystem>
 #include <unordered_set>
+#include <mutex>
 
 #include <shlwapi.h>
 #include <windows.h>
 #include <winternl.h>
 
+#if __has_include(<spdlog/spdlog.h>)
 #include <spdlog/spdlog.h>
+#else
+#define SPDLOG_INFO(...)
+#define SPDLOG_ERROR(...)
+#define SPDLOG_DEBUG(...)
+#endif
 
 #include <utility/String.hpp>
 #include <utility/Thread.hpp>
@@ -462,7 +469,7 @@ namespace utility {
                         std::filesystem::copy_file(path, new_path, std::filesystem::copy_options::overwrite_existing, ec);
 
                         if (ec) {
-                            spdlog::error("Failed to copy DLL file: {}", ec.message());
+                            SPDLOG_ERROR("Failed to copy DLL file: {}", ec.message());
                         }
 
                         ec.clear();

--- a/src/PointerHook.cpp
+++ b/src/PointerHook.cpp
@@ -1,7 +1,14 @@
 #include <stdexcept>
 
 #include <windows.h>
+
+#if __has_include(<spdlog/spdlog.h>)
 #include <spdlog/spdlog.h>
+#else
+#define SPDLOG_INFO(...)
+#define SPDLOG_ERROR(...)
+#define SPDLOG_DEBUG(...)
+#endif
 
 #include <utility/PointerHook.hpp>
 

--- a/src/RTTI.cpp
+++ b/src/RTTI.cpp
@@ -8,7 +8,13 @@
 #include <mutex>
 #include <unordered_map>
 
+#if __has_include(<spdlog/spdlog.h>)
 #include <spdlog/spdlog.h>
+#else
+#define SPDLOG_INFO(...)
+#define SPDLOG_ERROR(...)
+#define SPDLOG_DEBUG(...)
+#endif
 
 #include <utility/Module.hpp>
 #include <utility/RTTI.hpp>
@@ -283,7 +289,7 @@ std::optional<uintptr_t> find_vtable(HMODULE m, std::string_view type_name) try 
 
     return std::nullopt;
 } catch(...) {
-    spdlog::error("rtti::find_vtable - exception");
+    SPDLOG_ERROR("rtti::find_vtable - exception");
     return std::nullopt;
 }
 
@@ -322,7 +328,7 @@ std::optional<uintptr_t> find_vtable_partial(HMODULE m, std::string_view type_na
 
     return std::nullopt;
 } catch(...) {
-    spdlog::error("rtti::find_vtable_partial - exception");
+    SPDLOG_ERROR("rtti::find_vtable_partial - exception");
     return std::nullopt;
 }
 
@@ -375,7 +381,7 @@ std::optional<uintptr_t> find_object_inline(HMODULE m, std::string_view type_nam
     const auto vtable = find_vtable(m, type_name);
 
     if (!vtable) {
-        spdlog::error("Failed to find object {} (Could not find vtable)", type_name);
+        SPDLOG_ERROR("Failed to find object {} (Could not find vtable)", type_name);
         return std::nullopt;
     }
 
@@ -411,7 +417,7 @@ std::optional<uintptr_t*> find_object_ptr(HMODULE m, std::string_view type_name)
     const auto vtables = find_vtables(m, type_name);
 
     if (vtables.empty()) {
-        spdlog::error("Failed to find object {} (Could not find vtable)", type_name);
+        SPDLOG_ERROR("Failed to find object {} (Could not find vtable)", type_name);
         return std::nullopt;
     }
 
@@ -445,7 +451,7 @@ std::optional<uintptr_t*> find_object_ptr(HMODULE vtable_module, uintptr_t begin
     const auto vtables = find_vtables(vtable_module, type_name);
 
     if (vtables.empty()) {
-        spdlog::error("Failed to find object {} (Could not find vtable)", type_name);
+        SPDLOG_ERROR("Failed to find object {} (Could not find vtable)", type_name);
         return std::nullopt;
     }
 
@@ -481,7 +487,7 @@ std::vector<uintptr_t*> find_objects_ptr(HMODULE m, std::string_view type_name) 
     const auto vtables = find_vtables(m, type_name);
 
     if (vtables.empty()) {
-        spdlog::error("Failed to find object {} (Could not find vtable)", type_name);
+        SPDLOG_ERROR("Failed to find object {} (Could not find vtable)", type_name);
         return {};
     }
 

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -1,4 +1,10 @@
+#if __has_include(<spdlog/spdlog.h>)
 #include <spdlog/spdlog.h>
+#else
+#define SPDLOG_INFO(...)
+#define SPDLOG_ERROR(...)
+#define SPDLOG_DEBUG(...)
+#endif
 
 #include <utility/Registry.hpp>
 
@@ -7,7 +13,7 @@ std::optional<uint32_t> get_registry_dword(HKEY key, std::string_view subkey, st
     HKEY subkey_handle{};
 
     if (auto res = RegOpenKeyExA(key, subkey.data(), 0, KEY_QUERY_VALUE, &subkey_handle); res != ERROR_SUCCESS) {
-        spdlog::error("({}) Failed to open registry key {}", res, subkey);
+        SPDLOG_ERROR("({}) Failed to open registry key {}", res, subkey);
         return std::nullopt;
     }
 
@@ -15,13 +21,13 @@ std::optional<uint32_t> get_registry_dword(HKEY key, std::string_view subkey, st
     DWORD size{};
 
     if (auto res = RegQueryValueExA(subkey_handle, value.data(), nullptr, &type, nullptr, &size); res != ERROR_SUCCESS) {
-        spdlog::error("({}) Failed to query registry value {}", res, value);
+        SPDLOG_ERROR("({}) Failed to query registry value {}", res, value);
         RegCloseKey(subkey_handle);
         return std::nullopt;
     }
 
     if (type != REG_DWORD) {
-        spdlog::error("Registry value is not of type REG_DWORD: {}", value);
+        SPDLOG_ERROR("Registry value is not of type REG_DWORD: {}", value);
         RegCloseKey(subkey_handle);
         return std::nullopt;
     }
@@ -29,7 +35,7 @@ std::optional<uint32_t> get_registry_dword(HKEY key, std::string_view subkey, st
     DWORD result{};
 
     if (auto res = RegQueryValueExA(subkey_handle, value.data(), nullptr, nullptr, (LPBYTE)&result, &size); res != ERROR_SUCCESS) {
-        spdlog::error("({}) Failed to query registry value 2 {}", res, value);
+        SPDLOG_ERROR("({}) Failed to query registry value 2 {}", res, value);
         RegCloseKey(subkey_handle);
         return std::nullopt;
     }

--- a/src/Scan.cpp
+++ b/src/Scan.cpp
@@ -8,7 +8,13 @@
 #include <deque>
 #include <shared_mutex>
 
+#if __has_include(<spdlog/spdlog.h>)
 #include <spdlog/spdlog.h>
+#else
+#define SPDLOG_INFO(...)
+#define SPDLOG_ERROR(...)
+#define SPDLOG_DEBUG(...)
+#endif
 
 #include <utility/Pattern.hpp>
 #include <utility/String.hpp>

--- a/src/Thread.cpp
+++ b/src/Thread.cpp
@@ -2,7 +2,14 @@
 
 #include <Windows.h>
 #include <TlHelp32.h>
+
+#if __has_include(<spdlog/spdlog.h>)
 #include <spdlog/spdlog.h>
+#else
+#define SPDLOG_INFO(...)
+#define SPDLOG_ERROR(...)
+#define SPDLOG_DEBUG(...)
+#endif
 
 #include <utility/Thread.hpp>
 

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -3,7 +3,13 @@
 #include <iostream>
 #include <random>
 
+#if __has_include(<spdlog/spdlog.h>)
 #include <spdlog/spdlog.h>
+#else
+#define SPDLOG_INFO(...)
+#define SPDLOG_ERROR(...)
+#define SPDLOG_DEBUG(...)
+#endif
 
 #include <utility/Scan.hpp>
 #include <utility/Module.hpp>


### PR DESCRIPTION
Wrapped include with `#if __has_include(<spdlog/spdlog.h>)`.

Changed `spdlog::` calls to an appropriate define.

Added 
```
#define SPDLOG_INFO(...)
#define SPDLOG_ERROR(...)
#define SPDLOG_DEBUG(...)
```
when spdlog is not available.

Module.cpp: added missing `#include <mutex>`