### PR TITLE
Module: fix compilation for x86

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -297,7 +297,7 @@ namespace utility {
 #if defined(_M_X64)
         auto peb = (PEB*)__readgsqword(0x60);
 #else
-        auto peb = (PEB*)__readfsdword(0x60);
+        auto peb = (PEB*)__readfsdword(0x30);
 #endif
 
         if (peb == nullptr) {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -294,7 +294,11 @@ namespace utility {
             return;
         }
 
+#if defined(_M_X64)
         auto peb = (PEB*)__readgsqword(0x60);
+#else
+        auto peb = (PEB*)__readfsdword(0x60);
+#endif
 
         if (peb == nullptr) {
             return;


### PR DESCRIPTION
Also a question: would making scanner work with x86 require a lot of work? I briefly checked `utility::scan_string`, it did work, but `utility::scan_displacement_reference` did not, returned nullopt.