### PR TITLE
Logging.hpp: define missing SPDLOG_WARN placeholder

### DIFF
--- a/include/utility/Logging.hpp
+++ b/include/utility/Logging.hpp
@@ -7,4 +7,5 @@
 #define SPDLOG_INFO(...)
 #define SPDLOG_ERROR(...)
 #define SPDLOG_DEBUG(...)
+#define SPDLOG_WARN(...)
 #endif


### PR DESCRIPTION
SPDLOG_WARN was used in [PDB.cpp](https://github.com/cursey/kananlib/blob/7109f03a487be4db05ff3950981c9d303a260680/src/PDB.cpp#L325) and [Scan.cpp](https://github.com/cursey/kananlib/blob/7109f03a487be4db05ff3950981c9d303a260680/src/Scan.cpp#L1749), but Logging.hpp was not updated to account for that.