### PR TITLE
Add clang CI support

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -40,3 +40,27 @@ jobs:
       - name: Run all tests
         run: ctest --test-dir ${{github.workspace}}/test/build -C ${{env.BUILD_TYPE}} --output-on-failure
 
+  # Non-blocking: clang-cl is a supported compiler but the clang/MSVC-STL pairing
+  # on the GitHub runner can drift independently of our code. Keep this lane
+  # informational (continue-on-error) until it proves stable, then promote it to
+  # a required check. Uses the VS-bundled clang-cl toolset (-T ClangCL) so the
+  # STL version matches the toolchain.
+  test-clang:
+    runs-on: windows-latest
+    needs: build
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Configure CMake (clang-cl)
+        run: cmake -S ${{github.workspace}}/test -B ${{github.workspace}}/test/build-clang -G "Visual Studio 18 2026" -A x64 -T ClangCL -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+      - name: Build all tests (clang-cl)
+        run: cmake --build ${{github.workspace}}/test/build-clang --config ${{env.BUILD_TYPE}}
+
+      - name: Run all tests (clang-cl)
+        run: ctest --test-dir ${{github.workspace}}/test/build-clang -C ${{env.BUILD_TYPE}} --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/
 test/build
 test/kananlib
 test/build-cov
+test/build-clang
 
 # clang coverage profile dumps
 *.profraw

--- a/test/TestScanResolve.cpp
+++ b/test/TestScanResolve.cpp
@@ -138,8 +138,15 @@ int test_scan_ptr_hmodule() {
         std::cout << "  scan_ptr(HMODULE): no absolute pointer found (may be RIP-relative)" << std::endl;
     }
 
-    // Negative: search for a pointer that should not exist
-    const auto no_result = utility::scan_ptr(exe, (uintptr_t)0xDEADBEEFCAFEBABE);
+    // Negative: search for a pointer that cannot be embedded as an 8-byte
+    // immediate in the image. A fixed sentinel like 0xDEADBEEFCAFEBABE is not
+    // safe — some compilers (clang-cl) emit that exact byte run somewhere in
+    // .rdata/.text. Derive a high-entropy value at runtime instead.
+    LARGE_INTEGER qpc{};
+    QueryPerformanceCounter(&qpc);
+    const uintptr_t runtime_unique =
+        (static_cast<uintptr_t>(qpc.QuadPart) * 0x9E3779B97F4A7C15ULL) ^ 0xA5A5A5A5A5A5A5A5ULL;
+    const auto no_result = utility::scan_ptr(exe, runtime_unique);
     TEST_ASSERT(!no_result.has_value());
 
     return 0;
@@ -198,9 +205,16 @@ int test_find_function_from_string_ref_not_found() {
     HMODULE exe = utility::get_executable();
     TEST_ASSERT(exe != nullptr);
 
-    // Build a string at runtime so it won't exist in the binary's .rdata
+    // Build a high-entropy string at runtime so the byte run cannot exist in the
+    // binary's .rdata (a predictable run like 128+i can collide with compiler tables).
+    LARGE_INTEGER qpc{};
+    QueryPerformanceCounter(&qpc);
+    uint64_t state = static_cast<uint64_t>(qpc.QuadPart) ^ 0xC0FFEE1234567ULL;
     std::string fake_str(64, '\0');
-    for (int i = 0; i < 64; ++i) fake_str[i] = static_cast<char>(128 + i);
+    for (int i = 0; i < 64; ++i) {
+        state = state * 6364136223846793005ULL + 1442695040888963407ULL; // LCG
+        fake_str[i] = static_cast<char>(0x80 | ((state >> 48) & 0x7F));
+    }
 
     const auto fn = utility::find_function_from_string_ref(
         exe, std::string_view{fake_str});
@@ -217,9 +231,18 @@ int test_find_function_from_string_ref_wide_not_found() {
     HMODULE exe = utility::get_executable();
     TEST_ASSERT(exe != nullptr);
 
-    // Build a wide string at runtime so it won't exist in the binary's .rdata
+    // Build a wide string from a high-entropy runtime value so the byte run
+    // cannot appear in the image. A predictable monotonic run (0x8000+i) is not
+    // safe — clang-cl emits a matching incrementing 16-bit table in .rdata.
+    LARGE_INTEGER qpc{};
+    QueryPerformanceCounter(&qpc);
+    uint64_t state = static_cast<uint64_t>(qpc.QuadPart) ^ 0x123456789ABCDEFULL;
     std::wstring fake_wstr(32, L'\0');
-    for (int i = 0; i < 32; ++i) fake_wstr[i] = static_cast<wchar_t>(0x8000 + i);
+    for (int i = 0; i < 32; ++i) {
+        state = state * 6364136223846793005ULL + 1442695040888963407ULL; // LCG
+        // Keep chars in the BMP private-use area, away from any real .rdata text.
+        fake_wstr[i] = static_cast<wchar_t>(0xE000 + (state >> 48) % 0x1800);
+    }
 
     const auto fn = utility::find_function_from_string_ref(
         exe, std::wstring_view{fake_wstr});


### PR DESCRIPTION
This pull request improves the reliability of the test suite and CI by addressing false negatives in tests related to pointer and string scanning, and by adding a new CI job for `clang-cl` on Windows. The most important changes are:

**CI improvements:**

* Added a new, non-blocking `test-clang` job to `.github/workflows/dev-release.yml` to run tests using the `clang-cl` compiler with the Visual Studio STL on Windows. This helps detect issues specific to the clang/MSVC-STL toolchain pairing and will be promoted to a required check once stable.

**Test robustness:**

* Updated negative test cases in `test/TestScanResolve.cpp` to generate high-entropy runtime values instead of using fixed or predictable patterns. This avoids accidental matches with compiler-emitted data (especially with `clang-cl`), preventing false test failures:
  * The pointer scanning test now derives a unique value at runtime using `QueryPerformanceCounter` and a hash, rather than a fixed sentinel value.
  * The string and wide string scanning tests now generate high-entropy, runtime-only data using a linear congruential generator (LCG) seeded from `QueryPerformanceCounter`, ensuring the test data cannot collide with compiler-generated tables. [[1]](diffhunk://#diff-babc1039feebfb816ab6bc765a4050f3d91a86601cc75d53823f506aab1d3550L201-R217) [[2]](diffhunk://#diff-babc1039feebfb816ab6bc765a4050f3d91a86601cc75d53823f506aab1d3550L220-R245)